### PR TITLE
Removed log4net.Config.BasicConfigurator.Configure calls

### DIFF
--- a/aaLogReader/aaLogReader.cs
+++ b/aaLogReader/aaLogReader.cs
@@ -35,9 +35,6 @@ namespace aaLogReader
         /// </summary>
         public aaLogReader()
         {
-            // Setup logging
-            log4net.Config.BasicConfigurator.Configure();
-
             log.Debug("Create aaLogReader");            
 
             // Initialize with default options
@@ -53,9 +50,6 @@ namespace aaLogReader
         ///<param name="InitializationOptions">InitializationOptions passed as an OptionsStruct object </param>
         public aaLogReader(OptionsStruct InitializationOptions)
         {
-            // Setup logging
-            log4net.Config.BasicConfigurator.Configure();
-
             log.Debug("Create aaLogReader");
             log.Debug("Options - " + JsonConvert.SerializeObject(InitializationOptions));
 


### PR DESCRIPTION
This is for issue 13, removing calls to log4net.Config.BasicConfigurator.Configure() from aaLogReader so it will not reset the log4net configuration.