### PR TITLE
Removed log4net.Config.XmlConfigurator call

### DIFF
--- a/aaLogReader/aaLogReader.cs
+++ b/aaLogReader/aaLogReader.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Net;
 using System.Net.NetworkInformation;
 
-[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log.config", Watch = true)]
 namespace aaLogReader
 {
 	public class aaLogReader : IDisposable


### PR DESCRIPTION
For issue #21 to let log4net configuration be handled by the host application.