### PR TITLE
Multi-thread changes to aaLogReader

### DIFF
--- a/aaLogReader.Tests/aaLogBaseTest.cs
+++ b/aaLogReader.Tests/aaLogBaseTest.cs
@@ -1,0 +1,74 @@
+﻿using aaLogReader.Helpers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.IO;
+
+namespace aaLogReader.Tests
+{
+    public class aaLogBaseTest
+    {
+        public static readonly string TEST_PATH = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+        protected readonly string ROOT_FILE_PATH = "INVALID$DIRECTORY";
+
+        private readonly string _expectedFqdn;
+
+        public aaLogBaseTest(string rootFilePath)
+        {
+            //ROOT_FILE_PATH = Path.Combine(TEST_PATH, rootFilePath);
+            ROOT_FILE_PATH = rootFilePath;
+            _expectedFqdn = Fqdn.GetFqdn();
+        }
+
+        public string ExpectedFqdn
+        {
+            get { return _expectedFqdn; }
+        }
+
+        public void AreEqual(string fileName, LogHeader actualObj, string optionalMessage = null)
+        {
+            string expectedText = File.ReadAllText(Path.Combine(ROOT_FILE_PATH, fileName));
+            var expectedObj = JsonConvert.DeserializeObject<LogHeader>(expectedText);
+            AreEqual(expectedObj, actualObj, optionalMessage);
+        }
+
+        public void AreEqual(LogHeader expected, LogHeader actual, string optionalMessage = null)
+        {
+            Assert.AreEqual(expected.LogFilePath, actual.LogFilePath, "LogFilePath is wrong");
+            Assert.AreEqual(expected.StartMsgNumber, actual.StartMsgNumber, "StartMsgNumber is wrong");
+            Assert.AreEqual(expected.MsgCount, actual.MsgCount, "MsgCount is wrong");
+            Assert.AreEqual(expected.EndMsgNumber, actual.EndMsgNumber, "EndMsgNumber is wrong");
+            Assert.AreEqual(expected.StartFileTime, actual.StartFileTime, "StartFileTime is wrong");
+            Assert.AreEqual(expected.EndFileTime, actual.EndFileTime, "EndFileTime is wrong");
+            Assert.AreEqual(expected.OffsetFirstRecord, actual.OffsetFirstRecord, "OffsetFirstRecord is wrong");
+            Assert.AreEqual(expected.OffsetLastRecord, actual.OffsetLastRecord, "OffsetLastRecord is wrong");
+            Assert.AreEqual(expected.ComputerName, actual.ComputerName, "ComputerName is wrong");
+            Assert.AreEqual(expected.Session, actual.Session, "Session is wrong");
+            Assert.AreEqual(expected.PrevFileName, actual.PrevFileName, "PrevFileName is wrong");
+            // This is not really a property of the source LogRecord, but of the reader
+            //Assert.AreEqual(expected.HostFQDN, ExpectedFqdn, "HostFQDN is wrong");
+        }
+
+        public void AreEqual(string fileName, LogRecord actualObj, string optionalMessage = null)
+        {
+            string expectedText = File.ReadAllText(Path.Combine(ROOT_FILE_PATH, fileName));
+            var expectedObj = JsonConvert.DeserializeObject<LogRecord>(expectedText);
+            AreEqual(expectedObj, actualObj, optionalMessage);
+        }
+
+        public void AreEqual(LogRecord expected, LogRecord actual, string optionalMessage = null)
+        {
+            Assert.AreEqual(expected.MessageNumber, actual.MessageNumber, "MessageNumber is wrong");
+            Assert.AreEqual(expected.ProcessID, expected.ProcessID, "ProcessID is wrong");
+            Assert.AreEqual(expected.ThreadID, expected.ThreadID, "ThreadID is wrong");
+            Assert.AreEqual(expected.EventFileTime, actual.EventFileTime, "EventFileTime is wrong");
+            Assert.AreEqual(expected.LogFlag, actual.LogFlag, "LogFlag is wrong");
+            Assert.AreEqual(expected.Component, actual.Component, "Component is wrong");
+            Assert.AreEqual(expected.Message, actual.Message, "Message is wrong");
+            Assert.AreEqual(expected.ProcessName, actual.ProcessName, "ProcessName is wrong");
+            Assert.AreEqual(expected.SessionID, actual.SessionID, "SessionID is wrong");
+            // This is not really a property of the source LogRecord, but of the reader
+            //Assert.AreEqual(expected.HostFQDN, ExpectedFqdn, "HostFQDN is wrong");
+        }
+    }
+}

--- a/aaLogReader.Tests/aaLogReader.Tests.csproj
+++ b/aaLogReader.Tests/aaLogReader.Tests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="aaLgxReaderTests\aaLgxReaderTests.cs" />
+    <Compile Include="aaLogBaseTest.cs" />
     <Compile Include="aaLogReaderTests\aaLogReaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/aaLogReader.Tests/aaLogReaderTests/aaLogReaderTests.cs
+++ b/aaLogReader.Tests/aaLogReaderTests/aaLogReaderTests.cs
@@ -267,13 +267,13 @@ namespace aaLogReader.Tests.aaLogReaderTests
 
             foreach (LogHeader lh in logHeaders)
             {
-                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.StartDateTime).Exists(x => x == lh.LogFilePath),
+                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.StartDateTimeUtc).Exists(x => x == lh.LogFilePath),
                     "End Message Timestamp log path not correctly identified");
-                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.EndDateTime).Exists(x => x == lh.LogFilePath),
+                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.EndDateTimeUtc).Exists(x => x == lh.LogFilePath),
                     "Start Mesage Timestamp log path not correctly identified");
                 Assert.That(
                     _logReader.GetLogFilePathsForMessageTimestamp(
-                        lh.StartDateTime.AddSeconds(lh.EndDateTime.Subtract(lh.StartDateTime).Seconds/2))
+                        lh.StartDateTimeUtc.AddSeconds(lh.EndDateTime.Subtract(lh.StartDateTime).Seconds/2))
                         .Exists(x => x == lh.LogFilePath), "Middle Message Timestamp log path not correctly identified");
             }
         }

--- a/aaLogReader.Tests/packages.config
+++ b/aaLogReader.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net451" />
 </packages>

--- a/aaLogReader/Types/ILogHeader.cs
+++ b/aaLogReader/Types/ILogHeader.cs
@@ -6,10 +6,12 @@ namespace aaLogReader
         string LogFilePath { get; set; }
         string ComputerName { get; set; }
         ulong EndFileTime { get; set; }
-        DateTime EndDateTime { get; }
+        DateTimeOffset EndDateTime { get; }
+        DateTime EndDateTimeLocal { get; }
+        DateTime EndDateTimeUtc { get; }
         string HostFQDN { get; set; }
         ulong MsgCount { get; set; }
-        ulong EndMsgNumber { get;}
+        ulong EndMsgNumber { get; }
         ulong StartMsgNumber { get; set; }
         int OffsetFirstRecord { get; set; }
         int OffsetLastRecord { get; set; }
@@ -17,7 +19,9 @@ namespace aaLogReader
         ReturnCodeStruct ReturnCode { get; set; }
         string Session { get; set; }
         ulong StartFileTime { get; set; }
-        DateTime StartDateTime { get;}
+        DateTimeOffset StartDateTime { get; }
+        DateTime StartDateTimeLocal { get; }
+        DateTime StartDateTimeUtc { get; }
         string ToCSV();
         string ToDelimitedString(char Delimiter = ',');
         string ToJSON();

--- a/aaLogReader/Types/ILogRecord.cs
+++ b/aaLogReader/Types/ILogRecord.cs
@@ -5,7 +5,9 @@ namespace aaLogReader
     {
         string Component { get; set; }
         DateTime EventDate { get; }
-        DateTime EventDateTime { get; }
+        DateTimeOffset EventDateTime { get; }
+        DateTime EventDateTimeLocal { get; }
+        DateTime EventDateTimeUtc { get; }
         ulong EventFileTime { get; set; }
         int EventMillisec { get; }
         string EventTime { get; }
@@ -21,7 +23,7 @@ namespace aaLogReader
         string SessionID { get; set; }
         uint ThreadID { get; set; }
         string ToCSV(ExportFormat format = ExportFormat.Full);
-        string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full);
+        string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full, DateTimeKind kind = DateTimeKind.Unspecified);
         string ToJSON();
         string ToKVP(ExportFormat format = ExportFormat.Full);
         string ToTSV(ExportFormat format = ExportFormat.Full);

--- a/aaLogReader/Types/LogHeader.cs
+++ b/aaLogReader/Types/LogHeader.cs
@@ -7,31 +7,80 @@ namespace aaLogReader
 {
     public class LogHeader : ILogHeader
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public string LogFilePath { get; set; }
 
         public ulong StartMsgNumber { get; set; }
 
         public ulong MsgCount { get; set; }
 
-        public ulong EndMsgNumber { 
+        public ulong EndMsgNumber
+        {
             get
             {
                 return (ulong)(checked(this.StartMsgNumber + this.MsgCount) - 1);
-            }                                
+            }
         }
 
-        public ulong StartFileTime { get; set; }
+        private ulong _startFileTime;
+        private DateTimeOffset _startDateTime;
 
-        public DateTime StartDateTime
+        public ulong StartFileTime
         {
-            get { return DateTime.FromFileTime((long)this.StartFileTime); }
+            get { return _startFileTime; }
+            set
+            {
+                _startFileTime = value;
+                _startDateTime = DateTimeOffset.FromFileTime((long)value);
+            }
         }
-        
-        public ulong EndFileTime { get; set; }
 
-        public DateTime EndDateTime
+        public DateTimeOffset StartDateTime
         {
-            get { return DateTime.FromFileTime((long)this.EndFileTime); }
+            get { return _startDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime StartDateTimeLocal
+        {
+            get { return _startDateTime.LocalDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime StartDateTimeUtc
+        {
+            get { return _startDateTime.UtcDateTime; }
+        }
+
+        private ulong _endFileTime;
+        private DateTimeOffset _endDateTime;
+
+        public ulong EndFileTime
+        {
+            get { return _endFileTime; }
+            set
+            {
+                _endFileTime = value;
+                _endDateTime = DateTimeOffset.FromFileTime((long)value);
+            }
+        }
+
+        public DateTimeOffset EndDateTime
+        {
+            get { return _endDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EndDateTimeLocal
+        {
+            get { return _endDateTime.LocalDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EndDateTimeUtc
+        {
+            get { return _endDateTime.UtcDateTime; }
         }
 
         public int OffsetFirstRecord { get; set; }
@@ -80,9 +129,10 @@ namespace aaLogReader
                 localSB.AppendFormat(", HostFQDN=\"{0}\"", this.HostFQDN);
 
                 returnValue = localSB.ToString();
-            }            
-            catch
+            }
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -119,8 +169,9 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -174,8 +225,9 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -190,6 +242,18 @@ namespace aaLogReader
         public string ToTSV()
         {
             return this.ToDelimitedString('\t');
+        }
+
+#if NET45_OR_GREATER
+        private void LogException(Exception ex, [CallerMemberName]string methodName = "")
+        {
+#else
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private void LogException(Exception ex)
+        {
+            string methodName = new System.Diagnostics.StackFrame(1, false).GetMethod().Name;
+#endif
+            log.Error(string.Format("{0}: {1} - {2}", methodName, ex.GetType().Name, ex.Message), ex);
         }
     }
 }

--- a/aaLogReader/Types/LogRecord.cs
+++ b/aaLogReader/Types/LogRecord.cs
@@ -10,6 +10,8 @@ namespace aaLogReader
     /// </summary>
     public class LogRecord : ILogRecord
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // Default constructor
         public LogRecord()
         {
@@ -17,10 +19,10 @@ namespace aaLogReader
             this.ReturnCode.Message = "";
         }
 
-        [JsonIgnore]        
+        [JsonIgnore]
         public int RecordLength { get; set; }
 
-        [JsonIgnore]        
+        [JsonIgnore]
         public int OffsetToPrevRecord { get; set; }
 
         [JsonIgnore]
@@ -33,14 +35,37 @@ namespace aaLogReader
 
         public uint ThreadID { get; set; }
 
-        public ulong EventFileTime { get; set; }
+        private ulong _eventFileTime;
+        private DateTimeOffset _eventDateTime;
+
+        public ulong EventFileTime
+        {
+            get { return _eventFileTime; }
+            set
+            {
+                _eventFileTime = value;
+                _eventDateTime = DateTimeOffset.FromFileTime((long)value);
+            }
+        }
 
         // TODO: Add UTC Offset for Exact Timestamp
-        // public int EventUTCOffset; 
+        // public int EventUTCOffset;
 
-        public DateTime EventDateTime
+        public DateTimeOffset EventDateTime
         {
-            get { return DateTime.FromFileTime((long)this.EventFileTime); }
+            get { return _eventDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EventDateTimeLocal
+        {
+            get { return _eventDateTime.LocalDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EventDateTimeUtc
+        {
+            get { return _eventDateTime.UtcDateTime; }
         }
 
         [JsonIgnore]
@@ -61,7 +86,7 @@ namespace aaLogReader
         [JsonIgnore]
         public int EventMillisec
         {
-            get { return this.EventDateTime.Millisecond;}
+            get { return this.EventDateTime.Millisecond; }
         }
 
         public string LogFlag { get; set; }
@@ -114,14 +139,15 @@ namespace aaLogReader
                 }
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
             return returnValue;
         }
-        
+
         /// <summary>
         /// Get a header for a series of log records with a delimiter
         /// </summary>
@@ -156,14 +182,15 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
             return returnValue;
         }
-        
+
         public static string Header(char Delimiter = ',', ExportFormat format = ExportFormat.Full)
         {
             LogRecord lr = new LogRecord();
@@ -186,7 +213,7 @@ namespace aaLogReader
         /// <param name="Delimiter">Delimiter to Use</param>
         /// <param name="format">Full or Minimal</param>
         /// <returns></returns>
-        public string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full)
+        public string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full, DateTimeKind kind = DateTimeKind.Unspecified)
         {
 
             string returnValue;
@@ -194,8 +221,10 @@ namespace aaLogReader
 
             try
             {
-
-                localSB.Append("\"" + this.EventDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + "\"");
+                if (kind == DateTimeKind.Utc)
+                    localSB.Append("\"" + this.EventDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + "\"");
+                else
+                    localSB.Append("\"" + this.EventDateTimeUtc.ToString("yyyy-MM-dd HH:mm:ss.fffZ") + "\"");
                 localSB.Append(Delimiter + this.LogFlag);
                 localSB.Append(Delimiter + "\"" + this.Message + "\"");
                 localSB.Append(Delimiter + this.HostFQDN);
@@ -214,8 +243,9 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -229,7 +259,19 @@ namespace aaLogReader
 
         public string ToTSV(ExportFormat format = ExportFormat.Full)
         {
-            return this.ToDelimitedString('\t',format);
+            return this.ToDelimitedString('\t', format);
+        }
+
+#if NET45_OR_GREATER
+        private void LogException(Exception ex, [CallerMemberName]string methodName = "")
+        {
+#else
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private void LogException(Exception ex)
+        {
+            string methodName = new System.Diagnostics.StackFrame(1, false).GetMethod().Name;
+#endif
+            log.Error(string.Format("{0}: {1} - {2}", methodName, ex.GetType().Name, ex.Message), ex);
         }
     }
 }

--- a/aaLogReader/aaLogReader.cs
+++ b/aaLogReader/aaLogReader.cs
@@ -1,13 +1,10 @@
-﻿using System;
+﻿using aaLogReader.Helpers;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using aaLogReader.Helpers;
-using Newtonsoft.Json;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Net;
-using System.Net.NetworkInformation;
 
 namespace aaLogReader
 {

--- a/aaLogReader/aaLogReader.csproj
+++ b/aaLogReader/aaLogReader.csproj
@@ -13,6 +13,19 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- http://stackoverflow.com/a/12737781/29762 -->
+    <!-- Adding a custom constant will auto-magically append a comma and space to the pre-built constants.    -->
+    <!-- Move the comma delimiter to the end of each constant and remove the trailing comma when we're done.  -->
+    <DefineConstants Condition=" !$(DefineConstants.Contains(', NET')) ">$(DefineConstants)$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", "")), </DefineConstants>
+    <DefineConstants Condition=" $(DefineConstants.Contains(', NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(", NET"))))$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", "")), </DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 2.0 ">$(DefineConstants)NET20_OR_GREATER, </DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 3.5 ">$(DefineConstants)NET35_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 4.0 ">$(DefineConstants)NET40_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 4.5 ">$(DefineConstants)NET45_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 4.6 ">$(DefineConstants)NET46_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(DefineConstants.EndsWith(', ')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(", "))))</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>


### PR DESCRIPTION
I changed `LogHeader` and `LogRecord` to use `DateTimeOffset` instead of `DateTime`.

I also tried to fix some of the multi-threaded issues in `aaLogReader` before I realized the multi-user issues make this effort obsolete. We still need to redesign `aaLogReader` as I mentioned in #26.