### PR TITLE
aaLogReader unit tests with objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
+*.bak
 
 # SQL Server files
 *.mdf

--- a/aaLogReader.Tests/aaLgxReaderTests/aaLgxReaderTests.cs
+++ b/aaLogReader.Tests/aaLgxReaderTests/aaLgxReaderTests.cs
@@ -4,33 +4,43 @@ using NUnit.Framework;
 namespace aaLogReader.Tests.aaLgxReaderTests
 {
     [TestFixture]
-    public class aaLgxReaderTests
+    public class aaLgxReaderTests : aaLogBaseTest
     {
-        private const string LOG_FILE_PATH = @"aaLgxReaderTests\logFiles\test.aaLGX";
+        private const string ROOT_FILE_PATH = @"aaLgxReaderTests";
+        private const string LOG_FILE_PATH = ROOT_FILE_PATH + @"\logFiles";
+        private const string LOG_FILE_INSTANCE = LOG_FILE_PATH + @"\test.aaLGX";
+
+        static aaLgxReaderTests()
+        {
+            RootFilePath = ROOT_FILE_PATH;
+        }
 
         [Test]
         public void CanReadHeader()
         {
-            var header = aaLgxReader.ReadLogHeader(LOG_FILE_PATH);
-            Assert.That(header.LogFilePath, Is.EqualTo(LOG_FILE_PATH), "LogFilePath is wrong");
-            Assert.That(header.StartMsgNumber, Is.EqualTo(0), "StartMsgNumber is wrong");
-            Assert.That(header.MsgCount, Is.EqualTo(683), "MsgCount is wrong");
-            Assert.That(header.EndMsgNumber, Is.EqualTo(682), "EndMsgNumber is wrong");
-            Assert.That(header.StartFileTime, Is.EqualTo(130783241810947628), "StartFileTime is wrong");
-            Assert.That(header.EndFileTime, Is.EqualTo(130783316984931276), "EndFileTime is wrong");
-            Assert.That(header.OffsetFirstRecord, Is.EqualTo(68), "OffsetFirstRecord is wrong");
-            Assert.That(header.OffsetLastRecord, Is.EqualTo(191760), "OffsetLastRecord is wrong");
-            Assert.That(header.ComputerName, Is.EqualTo("DSA2014R2"), "ComputerName is wrong");
-            Assert.That(header.Session, Is.Null, "Session is wrong");
-            Assert.That(header.PrevFileName, Is.Null, "PrevFileName is wrong");
-            Assert.That(header.HostFQDN, Is.Null, "HostFQDN is wrong");
+            var actual = aaLgxReader.ReadLogHeader(LOG_FILE_INSTANCE);
+            var expected = new LogHeader
+            {
+                LogFilePath = LOG_FILE_INSTANCE,
+                StartMsgNumber = 0,
+                MsgCount = 683,
+                StartFileTime = 130783241810947628,
+                EndFileTime = 130783316984931276,
+                OffsetFirstRecord = 68,
+                OffsetLastRecord = 191760,
+                ComputerName = "DSA2014R2",
+                Session = null,
+                PrevFileName = null,
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
 
         [Test]
         public void ReadsCorrectNumberOfRecords()
         {
-            var header = aaLgxReader.ReadLogHeader(LOG_FILE_PATH);
-            var records = aaLgxReader.ReadLogRecords(LOG_FILE_PATH);
+            var header = aaLgxReader.ReadLogHeader(LOG_FILE_INSTANCE);
+            var records = aaLgxReader.ReadLogRecords(LOG_FILE_INSTANCE);
             Assert.That(header.MsgCount, Is.GreaterThan(0), "MsgCount should not be zero");
             Assert.That(header.MsgCount, Is.EqualTo(records.Count()), "MsgCount does not match records count");
         }
@@ -38,68 +48,75 @@ namespace aaLogReader.Tests.aaLgxReaderTests
         [Test]
         public void CanReadFirstRecord()
         {
-            var records = aaLgxReader.ReadLogRecords(LOG_FILE_PATH);
-            var record = records.First();
-            Assert.That(record.RecordLength, Is.EqualTo(106), "RecordLength is wrong");
-            Assert.That(record.OffsetToPrevRecord, Is.EqualTo(0), "OffsetToPrevRecord is wrong");
-            Assert.That(record.OffsetToNextRecord, Is.EqualTo(174), "OffsetToNextRecord is wrong");
-            Assert.That(record.MessageNumber, Is.EqualTo(360097), "MessageNumber is wrong");
-            Assert.That(record.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(record.ProcessID, Is.EqualTo(1076), "ProcessID is wrong");
-            Assert.That(record.ThreadID, Is.EqualTo(1096), "ThreadID is wrong");
-            Assert.That(record.EventFileTime, Is.EqualTo(130783241810947628), "EventFileTime is wrong");
-            Assert.That(record.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(record.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(record.Message, Is.EqualTo("Logger Started."), "Message is wrong");
-            Assert.That(record.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(record.HostFQDN, Is.Null, "HostFQDN is wrong");
+            var records = aaLgxReader.ReadLogRecords(LOG_FILE_INSTANCE);
+            var actual = records.First();
+            var expected = new LogRecord
+            {
+                MessageNumber = 360097,
+                RecordLength = 106,
+                OffsetToPrevRecord = 0,
+                OffsetToNextRecord = 174,
+                ProcessID = 1076,
+                ProcessName = "",
+                SessionID = "0.0.0.0",
+                ThreadID = 1096,
+                EventFileTime = 130783241810947628,
+                LogFlag = "Info",
+                Component = "aaLogger",
+                Message = "Logger Started.",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
 
         [Test]
         public void CanReadEighteenthRecord()
         {
             // Picked this one because it has a long-ish message and a warning flag.
-            var records = aaLgxReader.ReadLogRecords(LOG_FILE_PATH);
-            var record = records.Skip(17).Take(1).First();
-            Assert.That(record.RecordLength, Is.EqualTo(1076), "RecordLength is wrong");
-            Assert.That(record.OffsetToPrevRecord, Is.EqualTo(6076), "OffsetToPrevRecord is wrong");
-            Assert.That(record.OffsetToNextRecord, Is.EqualTo(7492), "OffsetToNextRecord is wrong");
-            Assert.That(record.MessageNumber, Is.EqualTo(360114), "MessageNumber is wrong");
-            Assert.That(record.SessionID, Is.EqualTo("25.46.254.255"), "SessionID is wrong");
-            Assert.That(record.ProcessID, Is.EqualTo(1164), "ProcessID is wrong");
-            Assert.That(record.ThreadID, Is.EqualTo(1196), "ThreadID is wrong");
-            Assert.That(record.EventFileTime, Is.EqualTo(130783242256451623), "EventFileTime is wrong");
-            Assert.That(record.LogFlag, Is.EqualTo("Warning"), "LogFlag is wrong");
-            Assert.That(record.Component, Is.EqualTo("IMS.Server.Runtime"), "Component is wrong");
-            Assert.That(record.Message,
-                Is.EqualTo(
-                    @"A connection attempt to the database server on machine DSA2014R2 failed (attempt 1 of 10). Will try again in 30 seconds.
-A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)"),
-                "Message is wrong");
-            Assert.That(record.ProcessName, Is.EqualTo("aaInformationModelService"), "ProcessName is wrong");
-            Assert.That(record.HostFQDN, Is.Null, "HostFQDN is wrong");
+            var records = aaLgxReader.ReadLogRecords(LOG_FILE_INSTANCE);
+            var actual = records.Skip(17).Take(1).First();
+            var expected = new LogRecord
+            {
+                MessageNumber = 360114,
+                RecordLength = 1076,
+                OffsetToPrevRecord = 6076,
+                OffsetToNextRecord = 7492,
+                ProcessID = 1164,
+                ProcessName = "aaInformationModelService",
+                SessionID = "25.46.254.255",
+                ThreadID = 1196,
+                EventFileTime = 130783242256451623,
+                LogFlag = "Warning",
+                Component = "IMS.Server.Runtime",
+                Message = @"A connection attempt to the database server on machine DSA2014R2 failed (attempt 1 of 10). Will try again in 30 seconds.
+A network-related or instance-specific error occurred while establishing a connection to SQL Server. The server was not found or was not accessible. Verify that the instance name is correct and that SQL Server is configured to allow remote connections. (provider: Named Pipes Provider, error: 40 - Could not open a connection to SQL Server)",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
 
         [Test]
         public void CanReadLastRecord()
         {
-            var records = aaLgxReader.ReadLogRecords(LOG_FILE_PATH);
-            var record = records.Last();
-            Assert.That(record.RecordLength, Is.EqualTo(254), "RecordLength is wrong");
-            Assert.That(record.OffsetToPrevRecord, Is.EqualTo(191470), "OffsetToPrevRecord is wrong");
-            Assert.That(record.OffsetToNextRecord, Is.EqualTo(192014), "OffsetToNextRecord is wrong");
-            Assert.That(record.MessageNumber, Is.EqualTo(360779), "MessageNumber is wrong");
-            Assert.That(record.SessionID, Is.EqualTo("74.119.223.42"), "SessionID is wrong");
-            Assert.That(record.ProcessID, Is.EqualTo(7912), "ProcessID is wrong");
-            Assert.That(record.ThreadID, Is.EqualTo(6712), "ThreadID is wrong");
-            Assert.That(record.EventFileTime, Is.EqualTo(130783316984931276), "EventFileTime is wrong");
-            Assert.That(record.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(record.Component, Is.EqualTo("aahIDASSvc (local)"), "Component is wrong");
-            Assert.That(record.Message,
-                Is.EqualTo("DSA2014R2_2: Sending SuiteLink time synchronization message DSA2014R2"),
-                "Message is wrong");
-            Assert.That(record.ProcessName, Is.EqualTo("aahIDASSvc"), "ProcessName is wrong");
-            Assert.That(record.HostFQDN, Is.Null, "HostFQDN is wrong");
+            var records = aaLgxReader.ReadLogRecords(LOG_FILE_INSTANCE);
+            var actual = records.Last();
+            var expected = new LogRecord
+            {
+                MessageNumber = 360779,
+                RecordLength = 254,
+                OffsetToPrevRecord = 191470,
+                OffsetToNextRecord = 192014,
+                ProcessID = 7912,
+                ProcessName = "aahIDASSvc",
+                SessionID = "74.119.223.42",
+                ThreadID = 6712,
+                EventFileTime = 130783316984931276,
+                LogFlag = "Info",
+                Component = "aahIDASSvc (local)",
+                Message = "DSA2014R2_2: Sending SuiteLink time synchronization message DSA2014R2",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
     }
 }

--- a/aaLogReader.Tests/aaLogBaseTest.cs
+++ b/aaLogReader.Tests/aaLogBaseTest.cs
@@ -1,0 +1,74 @@
+﻿using aaLogReader.Helpers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System.IO;
+
+namespace aaLogReader.Tests
+{
+    public class aaLogBaseTest
+    {
+        public static readonly string TEST_PATH = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+        protected readonly string ROOT_FILE_PATH = "INVALID$DIRECTORY";
+
+        private readonly string _expectedFqdn;
+
+        public aaLogBaseTest(string rootFilePath)
+        {
+            //ROOT_FILE_PATH = Path.Combine(TEST_PATH, rootFilePath);
+            ROOT_FILE_PATH = rootFilePath;
+            _expectedFqdn = Fqdn.GetFqdn();
+        }
+
+        public string ExpectedFqdn
+        {
+            get { return _expectedFqdn; }
+        }
+
+        public void AreEqual(string fileName, LogHeader actualObj, string optionalMessage = null)
+        {
+            string expectedText = File.ReadAllText(Path.Combine(ROOT_FILE_PATH, fileName));
+            var expectedObj = JsonConvert.DeserializeObject<LogHeader>(expectedText);
+            AreEqual(expectedObj, actualObj, optionalMessage);
+        }
+
+        public void AreEqual(LogHeader expected, LogHeader actual, string optionalMessage = null)
+        {
+            Assert.AreEqual(expected.LogFilePath, actual.LogFilePath, "LogFilePath is wrong");
+            Assert.AreEqual(expected.StartMsgNumber, actual.StartMsgNumber, "StartMsgNumber is wrong");
+            Assert.AreEqual(expected.MsgCount, actual.MsgCount, "MsgCount is wrong");
+            Assert.AreEqual(expected.EndMsgNumber, actual.EndMsgNumber, "EndMsgNumber is wrong");
+            Assert.AreEqual(expected.StartFileTime, actual.StartFileTime, "StartFileTime is wrong");
+            Assert.AreEqual(expected.EndFileTime, actual.EndFileTime, "EndFileTime is wrong");
+            Assert.AreEqual(expected.OffsetFirstRecord, actual.OffsetFirstRecord, "OffsetFirstRecord is wrong");
+            Assert.AreEqual(expected.OffsetLastRecord, actual.OffsetLastRecord, "OffsetLastRecord is wrong");
+            Assert.AreEqual(expected.ComputerName, actual.ComputerName, "ComputerName is wrong");
+            Assert.AreEqual(expected.Session, actual.Session, "Session is wrong");
+            Assert.AreEqual(expected.PrevFileName, actual.PrevFileName, "PrevFileName is wrong");
+            // This is not really a property of the source LogRecord, but of the reader
+            //Assert.AreEqual(expected.HostFQDN, ExpectedFqdn, "HostFQDN is wrong");
+        }
+
+        public void AreEqual(string fileName, LogRecord actualObj, string optionalMessage = null)
+        {
+            string expectedText = File.ReadAllText(Path.Combine(ROOT_FILE_PATH, fileName));
+            var expectedObj = JsonConvert.DeserializeObject<LogRecord>(expectedText);
+            AreEqual(expectedObj, actualObj, optionalMessage);
+        }
+
+        public void AreEqual(LogRecord expected, LogRecord actual, string optionalMessage = null)
+        {
+            Assert.AreEqual(expected.MessageNumber, actual.MessageNumber, "MessageNumber is wrong");
+            Assert.AreEqual(expected.ProcessID, expected.ProcessID, "ProcessID is wrong");
+            Assert.AreEqual(expected.ThreadID, expected.ThreadID, "ThreadID is wrong");
+            Assert.AreEqual(expected.EventFileTime, actual.EventFileTime, "EventFileTime is wrong");
+            Assert.AreEqual(expected.LogFlag, actual.LogFlag, "LogFlag is wrong");
+            Assert.AreEqual(expected.Component, actual.Component, "Component is wrong");
+            Assert.AreEqual(expected.Message, actual.Message, "Message is wrong");
+            Assert.AreEqual(expected.ProcessName, actual.ProcessName, "ProcessName is wrong");
+            Assert.AreEqual(expected.SessionID, actual.SessionID, "SessionID is wrong");
+            // This is not really a property of the source LogRecord, but of the reader
+            //Assert.AreEqual(expected.HostFQDN, ExpectedFqdn, "HostFQDN is wrong");
+        }
+    }
+}

--- a/aaLogReader.Tests/aaLogBaseTest.cs
+++ b/aaLogReader.Tests/aaLogBaseTest.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using System;
 using System.IO;
 
 namespace aaLogReader.Tests
@@ -9,25 +10,34 @@ namespace aaLogReader.Tests
     public class aaLogBaseTest
     {
         public static readonly string TEST_PATH = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-        protected readonly string ROOT_FILE_PATH = "INVALID$DIRECTORY";
 
-        private readonly string _expectedFqdn;
+        private static readonly string _expectedFqdn;
+        private static string _rootFilePath;
 
-        public aaLogBaseTest(string rootFilePath)
+        static aaLogBaseTest()
         {
-            //ROOT_FILE_PATH = Path.Combine(TEST_PATH, rootFilePath);
-            ROOT_FILE_PATH = rootFilePath;
             _expectedFqdn = Fqdn.GetFqdn();
         }
 
-        public string ExpectedFqdn
+        public static string ExpectedFqdn
         {
             get { return _expectedFqdn; }
         }
 
+        public static string RootFilePath
+        {
+            get
+            {
+                if (_rootFilePath == null)
+                    throw new NotImplementedException();
+                return _rootFilePath;
+            }
+            protected set { _rootFilePath = value; }
+        }
+
         public void AreEqual(string fileName, LogHeader actualObj, string optionalMessage = null)
         {
-            string expectedText = File.ReadAllText(Path.Combine(ROOT_FILE_PATH, fileName));
+            string expectedText = File.ReadAllText(Path.Combine(RootFilePath, fileName));
             var expectedObj = JsonConvert.DeserializeObject<LogHeader>(expectedText);
             AreEqual(expectedObj, actualObj, optionalMessage);
         }
@@ -45,19 +55,22 @@ namespace aaLogReader.Tests
             Assert.AreEqual(expected.ComputerName, actual.ComputerName, "ComputerName is wrong");
             Assert.AreEqual(expected.Session, actual.Session, "Session is wrong");
             Assert.AreEqual(expected.PrevFileName, actual.PrevFileName, "PrevFileName is wrong");
-            // This is not really a property of the source LogRecord, but of the reader
+            // This is not really a property of the source LogHeader, but of the reader
             //Assert.AreEqual(expected.HostFQDN, ExpectedFqdn, "HostFQDN is wrong");
         }
 
         public void AreEqual(string fileName, LogRecord actualObj, string optionalMessage = null)
         {
-            string expectedText = File.ReadAllText(Path.Combine(ROOT_FILE_PATH, fileName));
+            string expectedText = File.ReadAllText(Path.Combine(RootFilePath, fileName));
             var expectedObj = JsonConvert.DeserializeObject<LogRecord>(expectedText);
             AreEqual(expectedObj, actualObj, optionalMessage);
         }
 
         public void AreEqual(LogRecord expected, LogRecord actual, string optionalMessage = null)
         {
+            Assert.AreEqual(expected.RecordLength, actual.RecordLength, "RecordLength is wrong");
+            Assert.AreEqual(expected.OffsetToPrevRecord, actual.OffsetToPrevRecord, "OffsetToPrevRecord is wrong");
+            Assert.AreEqual(expected.OffsetToNextRecord, actual.OffsetToNextRecord, "OffsetToNextRecord is wrong");
             Assert.AreEqual(expected.MessageNumber, actual.MessageNumber, "MessageNumber is wrong");
             Assert.AreEqual(expected.ProcessID, expected.ProcessID, "ProcessID is wrong");
             Assert.AreEqual(expected.ThreadID, expected.ThreadID, "ThreadID is wrong");

--- a/aaLogReader.Tests/aaLogReader.Tests.csproj
+++ b/aaLogReader.Tests/aaLogReader.Tests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="aaLgxReaderTests\aaLgxReaderTests.cs" />
+    <Compile Include="aaLogBaseTest.cs" />
     <Compile Include="aaLogReaderTests\aaLogReaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/aaLogReader.Tests/aaLogReaderTests/aaLogReaderTests.cs
+++ b/aaLogReader.Tests/aaLogReaderTests/aaLogReaderTests.cs
@@ -267,13 +267,13 @@ namespace aaLogReader.Tests.aaLogReaderTests
 
             foreach (LogHeader lh in logHeaders)
             {
-                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.StartDateTime).Exists(x => x == lh.LogFilePath),
+                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.StartDateTimeUtc).Exists(x => x == lh.LogFilePath),
                     "End Message Timestamp log path not correctly identified");
-                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.EndDateTime).Exists(x => x == lh.LogFilePath),
+                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.EndDateTimeUtc).Exists(x => x == lh.LogFilePath),
                     "Start Mesage Timestamp log path not correctly identified");
                 Assert.That(
                     _logReader.GetLogFilePathsForMessageTimestamp(
-                        lh.StartDateTime.AddSeconds(lh.EndDateTime.Subtract(lh.StartDateTime).Seconds/2))
+                        lh.StartDateTimeUtc.AddSeconds(lh.EndDateTime.Subtract(lh.StartDateTime).Seconds/2))
                         .Exists(x => x == lh.LogFilePath), "Middle Message Timestamp log path not correctly identified");
             }
         }

--- a/aaLogReader.Tests/aaLogReaderTests/aaLogReaderTests.cs
+++ b/aaLogReader.Tests/aaLogReaderTests/aaLogReaderTests.cs
@@ -7,22 +7,33 @@ using NUnit.Framework;
 namespace aaLogReader.Tests.aaLogReaderTests
 {
     [TestFixture]
-    public class aaLogReaderTests
+    public class aaLogReaderTests : aaLogBaseTest
     {
         private const string ROOT_FILE_PATH = @"aaLogReaderTests";
         private const string LOG_FILE_PATH = ROOT_FILE_PATH + @"\logFiles";
         private const string LOG_FILE_INSTANCE = LOG_FILE_PATH + @"\2014R2-VS-WSP1449897274.aaLog";
         private const string LOG_FILE_INSTANCE_MIDDLE = LOG_FILE_PATH + @"\2014R2-VS-WSP1449897274.aaLog";
 
-        private string _expectedFqdn;
-        private aaLogReader _logReader;
+        static aaLogReaderTests()
+        {
+            RootFilePath = ROOT_FILE_PATH;
+        }
+
+        /// <summary>
+        /// Create a new aaLogReader with the log path for the unit tests.
+        /// The method is used to avoid any possible multi-threaded issues in unit tests.
+        /// </summary>
+        /// <returns></returns>
+        private aaLogReader GetLogReader()
+        {
+            // Make sure the aaLogReader is looking at our test logs and not at the 
+            // default log file location.
+            return new aaLogReader(new OptionsStruct { LogDirectory = LOG_FILE_PATH });
+        }
 
         [TestFixtureSetUp]
         public void TestFixtureSetUp()
         {
-            // Cache this machine's FQDN.
-            _expectedFqdn = Fqdn.GetFqdn();
-
             // Cleanup any old cache files
             foreach (string filename in Directory.GetFiles(LOG_FILE_PATH, "*cache*"))
             {
@@ -30,73 +41,75 @@ namespace aaLogReader.Tests.aaLogReaderTests
             }
         }
 
-        [SetUp]
-        public void SetUp()
-        {
-            // Make sure the aaLogReader is looking at our test logs and not at the 
-            // default log file location.
-            _logReader = new aaLogReader(new OptionsStruct {LogDirectory = LOG_FILE_PATH});
-        }
-
         [Test]
         public void OpenCurrentLogFile()
         {
-            ReturnCodeStruct rcs = _logReader.OpenCurrentLogFile(LOG_FILE_PATH);
+            var logReader = GetLogReader();
+            var rcs = logReader.OpenCurrentLogFile(LOG_FILE_PATH);
 
             Assert.That(rcs.Status, Is.True, "Status is wrong");
             Assert.That(rcs.Message.Length, Is.EqualTo(0), "Message.Length is wrong");
+            Assert.That(logReader.CurrentLogFilePath, Contains.Substring(RootFilePath), "CurrentLogFilePath");
         }
 
         [Test]
         public void OpenCurrentLogFileWithOptions()
         {
-            ReturnCodeStruct rcs = _logReader.OpenCurrentLogFile();
+            var logReader = GetLogReader();
+            var rcs = logReader.OpenCurrentLogFile();
 
             Assert.That(rcs.Status, Is.True, "Status is wrong");
             Assert.That(rcs.Message.Length, Is.EqualTo(0), "Message.Length is wrong");
+            Assert.That(logReader.CurrentLogFilePath, Contains.Substring(RootFilePath), "CurrentLogFilePath");
         }
 
         [Test]
         public void OpenLogFile()
         {
-            ReturnCodeStruct rcs = _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            var rcs = logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
             Assert.That(rcs.Status, Is.True, "Status is wrong");
             Assert.That(rcs.Message.Length, Is.EqualTo(0), "Message.Length is wrong");
+            Assert.That(logReader.CurrentLogFilePath, Contains.Substring(RootFilePath), "CurrentLogFilePath");
         }
 
         [Test]
         public void ReadLogFileReadHeader()
         {
-            ReturnCodeStruct rcs = _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            var rcs = logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
             Assert.That(rcs.Status);
             Assert.That(rcs.Message.Length == 0);
 
-            var header = _logReader.CurrentLogHeader;
-            Assert.That(header.LogFilePath, Is.Null, "LogFilePath is wrong");
-            Assert.That(header.StartMsgNumber, Is.EqualTo(60380), "StartMsgNumber is wrong");
-            Assert.That(header.MsgCount, Is.EqualTo(5), "MsgCount is wrong");
-            Assert.That(header.EndMsgNumber, Is.EqualTo(60384), "EndMsgNumber is wrong");
-            Assert.That(header.StartFileTime, Is.EqualTo(130943708747330261), "StartFileTime is wrong");
-            Assert.That(header.EndFileTime, Is.EqualTo(130943708773045647), "EndFileTime is wrong");
-            Assert.That(header.OffsetFirstRecord, Is.EqualTo(160), "OffsetFirstRecord is wrong");
-            Assert.That(header.OffsetLastRecord, Is.EqualTo(718), "OffsetLastRecord is wrong");
-            Assert.That(header.ComputerName, Is.EqualTo("2014R2-VS-WSP"), "ComputerName is wrong");
-            Assert.That(header.Session, Is.EqualTo("Session"), "Session is wrong");
-            Assert.That(header.PrevFileName, Is.EqualTo("2014R2-VS-WSP1449897272.aaLOG"), "PrevFileName is wrong");
-            Assert.That(header.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual = logReader.CurrentLogHeader;
+            var expected = new LogHeader
+            {
+                StartMsgNumber = 60380,
+                MsgCount = 5,
+                StartFileTime = 130943708747330261,
+                EndFileTime = 130943708773045647,
+                OffsetFirstRecord = 160,
+                OffsetLastRecord = 718,
+                ComputerName = "2014R2-VS-WSP",
+                Session = "Session",
+                PrevFileName = "2014R2-VS-WSP1449897272.aaLOG",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
 
         [Test]
         public void CloseCurrentLogFile()
         {
-            ReturnCodeStruct rcs = _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            ReturnCodeStruct rcs = logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
             Assert.That(rcs.Status, Is.True, "Status is wrong");
             Assert.That(rcs.Message.Length, Is.EqualTo(0), "Message.Length is wrong");
 
-            rcs = _logReader.CloseCurrentLogFile();
+            rcs = logReader.CloseCurrentLogFile();
 
             Assert.That(rcs.Status, Is.True, "Status is wrong");
             Assert.That(rcs.Message.Length, Is.EqualTo(0), "Message.Length is wrong");
@@ -105,155 +118,171 @@ namespace aaLogReader.Tests.aaLogReaderTests
         [Test]
         public void CurrentLogFilePath()
         {
-            ReturnCodeStruct rcs = _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            var rcs = logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
             Assert.That(rcs.Status, Is.True, "Status is wrong");
             Assert.That(rcs.Message.Length, Is.EqualTo(0), "Message.Length is wrong");
 
-            Assert.That(_logReader.CurrentLogFilePath, Is.EqualTo(LOG_FILE_INSTANCE), "CurrentLogFilePath is wrong");
+            Assert.That(logReader.CurrentLogFilePath, Is.EqualTo(LOG_FILE_INSTANCE), "CurrentLogFilePath is wrong");
         }
 
         [Test]
         public void GetFirstRecord()
         {
-            _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
-            LogRecord lr = _logReader.GetFirstRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60380), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(9672), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(12224), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708747330261), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("Logger Started."), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual = logReader.GetFirstRecord();
+            var expected = new LogRecord
+            {
+                MessageNumber = 60380,
+                RecordLength = 94,
+                OffsetToPrevRecord = 0,
+                OffsetToNextRecord = 254,
+                ProcessID = 9672,
+                ProcessName = "",
+                SessionID = "0.0.0.0",
+                ThreadID = 12224,
+                EventFileTime = 130943708747330261,
+                LogFlag = "Info",
+                Component = "aaLogger",
+                Message = "Logger Started.",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
 
         [Test]
         public void GetNextRecordFromFirst()
         {
-            _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            var rcs = logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
-            LogRecord lr = _logReader.GetFirstRecord();
+            Assert.That(rcs.Status, Is.True, "Status is wrong");
 
-            lr = _logReader.GetNextRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60381), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(6844), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(6848), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708751488101), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Error"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("ScriptRuntime"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("LogGen_001.scr: Error Message 703"), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo("aaEngine"), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("40.119.32.23"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual0 = logReader.GetFirstRecord();
 
-            lr = _logReader.GetNextRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60382), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(6844), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(11372), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708752027927), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("ScriptRuntime"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("ServiceRestarter_001.scr: forcing restart of log viewer"), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo("aaEngine"), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("40.119.32.23"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual1 = logReader.GetNextRecord();
+            AreEqual(Expected_60381, actual1);
 
-            lr = _logReader.GetNextRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60383), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(9672), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(12224), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708752067116), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("Logger Shutting down."), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual2 = logReader.GetNextRecord();
+            AreEqual(Expected_60382, actual2);
+
+            var actual3 = logReader.GetNextRecord();
+            AreEqual(Expected_60383, actual3);
         }
 
         [Test]
         public void GetNextRecordFromLast()
         {
+            var logReader = GetLogReader();
+
             //Open a log file in the middle of the overall list of log files
-            _logReader.OpenLogFile(LOG_FILE_INSTANCE_MIDDLE);
-            Console.WriteLine(_logReader.CurrentLogFilePath);
+            logReader.OpenLogFile(LOG_FILE_INSTANCE_MIDDLE);
+            Console.WriteLine(logReader.CurrentLogFilePath);
 
-            LogRecord lr = _logReader.GetLastRecord();
+            var actual0 = logReader.GetLastRecord();
 
-            lr = _logReader.GetNextRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60385), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(9348), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(10740), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708773045647), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("Logger Started."), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual1 = logReader.GetNextRecord();
+            var expected1 = new LogRecord
+            {
+                MessageNumber = 60385,
+                RecordLength = 94,
+                OffsetToPrevRecord = 0,
+                OffsetToNextRecord = 254,
+                ProcessID = 9348,
+                ProcessName = "",
+                SessionID = "0.0.0.0",
+                ThreadID = 10740,
+                EventFileTime = 130943708773045647,
+                LogFlag = "Info",
+                Component = "aaLogger",
+                Message = "Logger Started.",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected1, actual1);
 
-            lr = _logReader.GetNextRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60386), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(6844), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(11272), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708777415338), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("ScriptRuntime"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("ServiceRestarter_001.scr: forcing restart of log viewer"), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo("aaEngine"), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("55.2.254.255"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual2 = logReader.GetNextRecord();
+            var expected2 = new LogRecord
+            {
+                MessageNumber = 60386,
+                RecordLength = 200,
+                OffsetToPrevRecord = 160,
+                OffsetToNextRecord = 454,
+                ProcessID = 6844,
+                ProcessName = "aaEngine",
+                SessionID = "55.2.254.255",
+                ThreadID = 11272,
+                EventFileTime = 130943708777415338,
+                LogFlag = "Info",
+                Component = "ScriptRuntime",
+                Message = "ServiceRestarter_001.scr: forcing restart of log viewer",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected2, actual2);
 
-            lr = _logReader.GetNextRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60387), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(9348), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(10740), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708777485254), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("Logger Shutting down."), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual3 = logReader.GetNextRecord();
+            var expected3 = new LogRecord
+            {
+                MessageNumber = 60387,
+                RecordLength = 106,
+                OffsetToPrevRecord = 254,
+                OffsetToNextRecord = 560,
+                ProcessID = 9348,
+                ProcessName = "",
+                SessionID = "0.0.0.0",
+                ThreadID = 10740,
+                EventFileTime = 130943708777485254,
+                LogFlag = "Info",
+                Component = "aaLogger",
+                Message = "Logger Shutting down.",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected3, actual3);
         }
 
         [Test]
         public void GetLastRecord()
         {
-            _logReader.OpenLogFile(LOG_FILE_INSTANCE);
+            var logReader = GetLogReader();
+            logReader.OpenLogFile(LOG_FILE_INSTANCE);
 
-            LogRecord lr = _logReader.GetLastRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60384), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(9348), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(10740), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708773045647), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("Logger Started."), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual = logReader.GetLastRecord();
+            var expected = new LogRecord
+            {
+                MessageNumber = 60384,
+                RecordLength = 94,
+                OffsetToPrevRecord = 612,
+                OffsetToNextRecord = 812,
+                ProcessID = 9348,
+                ProcessName = "",
+                SessionID = "0.0.0.0",
+                ThreadID = 10740,
+                EventFileTime = 130943708773045647,
+                LogFlag = "Info",
+                Component = "aaLogger",
+                Message = "Logger Started.",
+                HostFQDN = ExpectedFqdn,
+            };
+            AreEqual(expected, actual);
         }
 
         [Test]
         public void GetLogFilePathsForMessageFileTime()
         {
-            List<LogHeader> logHeaders = _logReader.LogHeaderIndex;
+            var logReader = GetLogReader();
+            var logHeaders = logReader.LogHeaderIndex;
 
             // Loop through all entries in the header index and verify we correctly identify the first, last, and middle message
-
-            foreach (LogHeader lh in logHeaders)
+            foreach (var lh in logHeaders)
             {
-                Assert.That(_logReader.GetLogFilePathsForMessageFileTime(lh.EndFileTime).Exists(x => x == lh.LogFilePath),
+                Assert.That(logReader.GetLogFilePathsForMessageFileTime(lh.EndFileTime).Exists(x => x == lh.LogFilePath),
                     "End FileTime log path not correctly identified");
-                Assert.That(_logReader.GetLogFilePathsForMessageFileTime(lh.StartFileTime).Exists(x => x == lh.LogFilePath),
+                Assert.That(logReader.GetLogFilePathsForMessageFileTime(lh.StartFileTime).Exists(x => x == lh.LogFilePath),
                     "Start FileTime log path not correctly identified");
                 Assert.That(
-                    _logReader.GetLogFilePathsForMessageFileTime((lh.StartFileTime + lh.EndFileTime)/2)
+                    logReader.GetLogFilePathsForMessageFileTime((lh.StartFileTime + lh.EndFileTime) / 2)
                         .Exists(x => x == lh.LogFilePath), "Middle FileTime log path not correctly identified");
             }
         }
@@ -261,19 +290,20 @@ namespace aaLogReader.Tests.aaLogReaderTests
         [Test]
         public void GetLogFilePathsForMessageTimestamp()
         {
-            List<LogHeader> logHeaders = _logReader.LogHeaderIndex;
+            var logReader = GetLogReader();
+            var logHeaders = logReader.LogHeaderIndex;
 
             // Loop through all entries in the header index and verify we correctly identify the first, last, and middle message
 
-            foreach (LogHeader lh in logHeaders)
+            foreach (var lh in logHeaders)
             {
-                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.StartDateTimeUtc).Exists(x => x == lh.LogFilePath),
+                Assert.That(logReader.GetLogFilePathsForMessageTimestamp(lh.StartDateTimeUtc).Exists(x => x == lh.LogFilePath),
                     "End Message Timestamp log path not correctly identified");
-                Assert.That(_logReader.GetLogFilePathsForMessageTimestamp(lh.EndDateTimeUtc).Exists(x => x == lh.LogFilePath),
+                Assert.That(logReader.GetLogFilePathsForMessageTimestamp(lh.EndDateTimeUtc).Exists(x => x == lh.LogFilePath),
                     "Start Mesage Timestamp log path not correctly identified");
                 Assert.That(
-                    _logReader.GetLogFilePathsForMessageTimestamp(
-                        lh.StartDateTimeUtc.AddSeconds(lh.EndDateTime.Subtract(lh.StartDateTime).Seconds/2))
+                    logReader.GetLogFilePathsForMessageTimestamp(
+                        lh.StartDateTimeUtc.AddSeconds(lh.EndDateTime.Subtract(lh.StartDateTime).Seconds / 2))
                         .Exists(x => x == lh.LogFilePath), "Middle Message Timestamp log path not correctly identified");
             }
         }
@@ -282,24 +312,25 @@ namespace aaLogReader.Tests.aaLogReaderTests
         public void GetLogFilePathsForMessageNumber()
         {
             ulong randomUlong;
-            Random rnd = new Random(DateTime.Now.Millisecond);
+            var rnd = new Random(DateTime.Now.Millisecond);
 
-            List<LogHeader> logHeaders = _logReader.LogHeaderIndex;
+            var logReader = GetLogReader();
+            var logHeaders = logReader.LogHeaderIndex;
 
             // Loop through all entries in the header index and verify we correctly identify the first, last, and middle message
 
-            foreach (LogHeader lh in logHeaders)
+            foreach (var lh in logHeaders)
             {
-                Assert.That(_logReader.GetLogFilePathsForMessageNumber(lh.StartMsgNumber).Exists(x => x == lh.LogFilePath),
+                Assert.That(logReader.GetLogFilePathsForMessageNumber(lh.StartMsgNumber).Exists(x => x == lh.LogFilePath),
                     "End Message Number log path not correctly identified");
-                Assert.That(_logReader.GetLogFilePathsForMessageNumber(lh.EndMsgNumber).Exists(x => x == lh.LogFilePath),
+                Assert.That(logReader.GetLogFilePathsForMessageNumber(lh.EndMsgNumber).Exists(x => x == lh.LogFilePath),
                     "Start Mesage Number log path not correctly identified");
                 Assert.That(
-                    _logReader.GetLogFilePathsForMessageNumber((lh.StartMsgNumber + lh.EndMsgNumber)/2)
+                    logReader.GetLogFilePathsForMessageNumber((lh.StartMsgNumber + lh.EndMsgNumber) / 2)
                         .Exists(x => x == lh.LogFilePath), "Middle Message Number log path not correctly identified");
 
-                randomUlong = (ulong) rnd.Next(Convert.ToInt32(lh.MsgCount)) + lh.StartMsgNumber;
-                Assert.That(_logReader.GetLogFilePathsForMessageNumber(randomUlong).Exists(x => x == lh.LogFilePath),
+                randomUlong = (ulong)rnd.Next(Convert.ToInt32(lh.MsgCount)) + lh.StartMsgNumber;
+                Assert.That(logReader.GetLogFilePathsForMessageNumber(randomUlong).Exists(x => x == lh.LogFilePath),
                     "Random Message Number " + randomUlong + " log path not correctly identified");
             }
         }
@@ -308,52 +339,30 @@ namespace aaLogReader.Tests.aaLogReaderTests
         [Test]
         public void GetPrevRecord()
         {
-            _logReader.OpenLogFile(LOG_FILE_INSTANCE_MIDDLE);
+            var logReader = GetLogReader();
+            logReader.OpenLogFile(LOG_FILE_INSTANCE_MIDDLE);
 
-            LogRecord lr = _logReader.GetLastRecord();
+            var actual4 = logReader.GetLastRecord();
 
-            lr = _logReader.GetPrevRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60383), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(9672), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(12224), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708752067116), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("aaLogger"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("Logger Shutting down."), "Message is wrong");
-            Assert.That(lr.ProcessName, Is.EqualTo(""), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("0.0.0.0"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual3 = logReader.GetPrevRecord();
+            AreEqual(Expected_60383, actual3);
 
-            lr = _logReader.GetPrevRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60382), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(6844), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(11372), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708752027927), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Info"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("ScriptRuntime"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("ServiceRestarter_001.scr: forcing restart of log viewer"));
-            Assert.That(lr.ProcessName, Is.EqualTo("aaEngine"), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("40.119.32.23"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual2 = logReader.GetPrevRecord();
+            AreEqual(Expected_60382, actual2);
 
-            lr = _logReader.GetPrevRecord();
-            Assert.That(lr.MessageNumber, Is.EqualTo(60381), "MessageNumber is wrong");
-            Assert.That(lr.ProcessID, Is.EqualTo(6844), "ProcessID is wrong");
-            Assert.That(lr.ThreadID, Is.EqualTo(6848), "ThreadID is wrong");
-            Assert.That(lr.EventFileTime, Is.EqualTo(130943708751488101), "EventFileTime is wrong");
-            Assert.That(lr.LogFlag, Is.EqualTo("Error"), "LogFlag is wrong");
-            Assert.That(lr.Component, Is.EqualTo("ScriptRuntime"), "Component is wrong");
-            Assert.That(lr.Message, Is.EqualTo("LogGen_001.scr: Error Message 703"));
-            Assert.That(lr.ProcessName, Is.EqualTo("aaEngine"), "ProcessName is wrong");
-            Assert.That(lr.SessionID, Is.EqualTo("40.119.32.23"), "SessionID is wrong");
-            Assert.That(lr.HostFQDN, Is.EqualTo(_expectedFqdn), "HostFQDN is wrong");
+            var actual1 = logReader.GetPrevRecord();
+            AreEqual(Expected_60381, actual1);
         }
 
-        //[Test]
-        //public void GetRecordByMessageNumber()
-        //{
-        //    Assert.That(false, "TODO");
-        //}
+        [Test]
+        public void GetRecordByMessageNumber()
+        {
+            var logReader = GetLogReader();
+            logReader.OpenLogFile(LOG_FILE_INSTANCE_MIDDLE);
+
+            var actual = logReader.GetRecordByMessageNumber(60383);
+            AreEqual(Expected_60383, actual);
+        }
 
         //[Test]
         //public void GetRecordByFileTime()
@@ -528,5 +537,58 @@ namespace aaLogReader.Tests.aaLogReaderTests
         //{
         //    Assert.Fail("TODO");
         //}
+
+        #region Shared Expected Result Objects
+        private static readonly LogRecord Expected_60381 = new LogRecord
+        {
+            MessageNumber = 60381,
+            RecordLength = 158,
+            OffsetToPrevRecord = 160,
+            OffsetToNextRecord = 412,
+            ProcessID = 6844,
+            ProcessName = "aaEngine",
+            SessionID = "40.119.32.23",
+            ThreadID = 6848,
+            EventFileTime = 130943708751488101,
+            LogFlag = "Error",
+            Component = "ScriptRuntime",
+            Message = "LogGen_001.scr: Error Message 703",
+            HostFQDN = ExpectedFqdn,
+        };
+
+        private static readonly LogRecord Expected_60382 = new LogRecord
+        {
+            MessageNumber = 60382,
+            RecordLength = 200,
+            OffsetToPrevRecord = 254,
+            OffsetToNextRecord = 612,
+            ProcessID = 6844,
+            ProcessName = "aaEngine",
+            SessionID = "40.119.32.23",
+            ThreadID = 11372,
+            EventFileTime = 130943708752027927,
+            LogFlag = "Info",
+            Component = "ScriptRuntime",
+            Message = "ServiceRestarter_001.scr: forcing restart of log viewer",
+            HostFQDN = ExpectedFqdn,
+        };
+
+        private static readonly LogRecord Expected_60383 = new LogRecord
+        {
+            RecordLength = 106,
+            OffsetToPrevRecord = 412,
+            OffsetToNextRecord = 718,
+            MessageNumber = 60383,
+            ProcessID = 9672,
+            ProcessName = "",
+            SessionID = "0.0.0.0",
+            ThreadID = 12224,
+            EventFileTime = 130943708752067116,
+            LogFlag = "Info",
+            Component = "aaLogger",
+            Message = "Logger Shutting down.",
+            HostFQDN = ExpectedFqdn,
+        };
+        #endregion
     }
 }

--- a/aaLogReader.Tests/packages.config
+++ b/aaLogReader.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net451" />
 </packages>

--- a/aaLogReader/Types/ILogHeader.cs
+++ b/aaLogReader/Types/ILogHeader.cs
@@ -6,10 +6,12 @@ namespace aaLogReader
         string LogFilePath { get; set; }
         string ComputerName { get; set; }
         ulong EndFileTime { get; set; }
-        DateTime EndDateTime { get; }
+        DateTimeOffset EndDateTime { get; }
+        DateTime EndDateTimeLocal { get; }
+        DateTime EndDateTimeUtc { get; }
         string HostFQDN { get; set; }
         ulong MsgCount { get; set; }
-        ulong EndMsgNumber { get;}
+        ulong EndMsgNumber { get; }
         ulong StartMsgNumber { get; set; }
         int OffsetFirstRecord { get; set; }
         int OffsetLastRecord { get; set; }
@@ -17,7 +19,9 @@ namespace aaLogReader
         ReturnCodeStruct ReturnCode { get; set; }
         string Session { get; set; }
         ulong StartFileTime { get; set; }
-        DateTime StartDateTime { get;}
+        DateTimeOffset StartDateTime { get; }
+        DateTime StartDateTimeLocal { get; }
+        DateTime StartDateTimeUtc { get; }
         string ToCSV();
         string ToDelimitedString(char Delimiter = ',');
         string ToJSON();

--- a/aaLogReader/Types/ILogRecord.cs
+++ b/aaLogReader/Types/ILogRecord.cs
@@ -5,7 +5,9 @@ namespace aaLogReader
     {
         string Component { get; set; }
         DateTime EventDate { get; }
-        DateTime EventDateTime { get; }
+        DateTimeOffset EventDateTime { get; }
+        DateTime EventDateTimeLocal { get; }
+        DateTime EventDateTimeUtc { get; }
         ulong EventFileTime { get; set; }
         int EventMillisec { get; }
         string EventTime { get; }
@@ -21,7 +23,7 @@ namespace aaLogReader
         string SessionID { get; set; }
         uint ThreadID { get; set; }
         string ToCSV(ExportFormat format = ExportFormat.Full);
-        string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full);
+        string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full, DateTimeKind kind = DateTimeKind.Unspecified);
         string ToJSON();
         string ToKVP(ExportFormat format = ExportFormat.Full);
         string ToTSV(ExportFormat format = ExportFormat.Full);

--- a/aaLogReader/Types/LogHeader.cs
+++ b/aaLogReader/Types/LogHeader.cs
@@ -7,31 +7,80 @@ namespace aaLogReader
 {
     public class LogHeader : ILogHeader
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         public string LogFilePath { get; set; }
 
         public ulong StartMsgNumber { get; set; }
 
         public ulong MsgCount { get; set; }
 
-        public ulong EndMsgNumber { 
+        public ulong EndMsgNumber
+        {
             get
             {
                 return (ulong)(checked(this.StartMsgNumber + this.MsgCount) - 1);
-            }                                
+            }
         }
 
-        public ulong StartFileTime { get; set; }
+        private ulong _startFileTime;
+        private DateTimeOffset _startDateTime;
 
-        public DateTime StartDateTime
+        public ulong StartFileTime
         {
-            get { return DateTime.FromFileTime((long)this.StartFileTime); }
+            get { return _startFileTime; }
+            set
+            {
+                _startFileTime = value;
+                _startDateTime = DateTimeOffset.FromFileTime((long)value);
+            }
         }
-        
-        public ulong EndFileTime { get; set; }
 
-        public DateTime EndDateTime
+        public DateTimeOffset StartDateTime
         {
-            get { return DateTime.FromFileTime((long)this.EndFileTime); }
+            get { return _startDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime StartDateTimeLocal
+        {
+            get { return _startDateTime.LocalDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime StartDateTimeUtc
+        {
+            get { return _startDateTime.UtcDateTime; }
+        }
+
+        private ulong _endFileTime;
+        private DateTimeOffset _endDateTime;
+
+        public ulong EndFileTime
+        {
+            get { return _endFileTime; }
+            set
+            {
+                _endFileTime = value;
+                _endDateTime = DateTimeOffset.FromFileTime((long)value);
+            }
+        }
+
+        public DateTimeOffset EndDateTime
+        {
+            get { return _endDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EndDateTimeLocal
+        {
+            get { return _endDateTime.LocalDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EndDateTimeUtc
+        {
+            get { return _endDateTime.UtcDateTime; }
         }
 
         public int OffsetFirstRecord { get; set; }
@@ -80,9 +129,10 @@ namespace aaLogReader
                 localSB.AppendFormat(", HostFQDN=\"{0}\"", this.HostFQDN);
 
                 returnValue = localSB.ToString();
-            }            
-            catch
+            }
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -119,8 +169,9 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -174,8 +225,9 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -190,6 +242,18 @@ namespace aaLogReader
         public string ToTSV()
         {
             return this.ToDelimitedString('\t');
+        }
+
+#if NET45_OR_GREATER
+        private void LogException(Exception ex, [CallerMemberName]string methodName = "")
+        {
+#else
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private void LogException(Exception ex)
+        {
+            string methodName = new System.Diagnostics.StackFrame(1, false).GetMethod().Name;
+#endif
+            log.Error(string.Format("{0}: {1} - {2}", methodName, ex.GetType().Name, ex.Message), ex);
         }
     }
 }

--- a/aaLogReader/Types/LogRecord.cs
+++ b/aaLogReader/Types/LogRecord.cs
@@ -10,6 +10,8 @@ namespace aaLogReader
     /// </summary>
     public class LogRecord : ILogRecord
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
         // Default constructor
         public LogRecord()
         {
@@ -17,10 +19,10 @@ namespace aaLogReader
             this.ReturnCode.Message = "";
         }
 
-        [JsonIgnore]        
+        [JsonIgnore]
         public int RecordLength { get; set; }
 
-        [JsonIgnore]        
+        [JsonIgnore]
         public int OffsetToPrevRecord { get; set; }
 
         [JsonIgnore]
@@ -33,14 +35,37 @@ namespace aaLogReader
 
         public uint ThreadID { get; set; }
 
-        public ulong EventFileTime { get; set; }
+        private ulong _eventFileTime;
+        private DateTimeOffset _eventDateTime;
+
+        public ulong EventFileTime
+        {
+            get { return _eventFileTime; }
+            set
+            {
+                _eventFileTime = value;
+                _eventDateTime = DateTimeOffset.FromFileTime((long)value);
+            }
+        }
 
         // TODO: Add UTC Offset for Exact Timestamp
-        // public int EventUTCOffset; 
+        // public int EventUTCOffset;
 
-        public DateTime EventDateTime
+        public DateTimeOffset EventDateTime
         {
-            get { return DateTime.FromFileTime((long)this.EventFileTime); }
+            get { return _eventDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EventDateTimeLocal
+        {
+            get { return _eventDateTime.LocalDateTime; }
+        }
+
+        [JsonIgnore]
+        public DateTime EventDateTimeUtc
+        {
+            get { return _eventDateTime.UtcDateTime; }
         }
 
         [JsonIgnore]
@@ -61,7 +86,7 @@ namespace aaLogReader
         [JsonIgnore]
         public int EventMillisec
         {
-            get { return this.EventDateTime.Millisecond;}
+            get { return this.EventDateTime.Millisecond; }
         }
 
         public string LogFlag { get; set; }
@@ -114,14 +139,15 @@ namespace aaLogReader
                 }
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
             return returnValue;
         }
-        
+
         /// <summary>
         /// Get a header for a series of log records with a delimiter
         /// </summary>
@@ -156,14 +182,15 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
             return returnValue;
         }
-        
+
         public static string Header(char Delimiter = ',', ExportFormat format = ExportFormat.Full)
         {
             LogRecord lr = new LogRecord();
@@ -186,7 +213,7 @@ namespace aaLogReader
         /// <param name="Delimiter">Delimiter to Use</param>
         /// <param name="format">Full or Minimal</param>
         /// <returns></returns>
-        public string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full)
+        public string ToDelimitedString(char Delimiter = ',', ExportFormat format = ExportFormat.Full, DateTimeKind kind = DateTimeKind.Unspecified)
         {
 
             string returnValue;
@@ -194,8 +221,10 @@ namespace aaLogReader
 
             try
             {
-
-                localSB.Append("\"" + this.EventDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + "\"");
+                if (kind == DateTimeKind.Utc)
+                    localSB.Append("\"" + this.EventDateTime.ToString("yyyy-MM-dd HH:mm:ss.fff") + "\"");
+                else
+                    localSB.Append("\"" + this.EventDateTimeUtc.ToString("yyyy-MM-dd HH:mm:ss.fffZ") + "\"");
                 localSB.Append(Delimiter + this.LogFlag);
                 localSB.Append(Delimiter + "\"" + this.Message + "\"");
                 localSB.Append(Delimiter + this.HostFQDN);
@@ -214,8 +243,9 @@ namespace aaLogReader
 
                 returnValue = localSB.ToString();
             }
-            catch
+            catch (Exception ex)
             {
+                LogException(ex);
                 returnValue = "";
             }
 
@@ -229,7 +259,19 @@ namespace aaLogReader
 
         public string ToTSV(ExportFormat format = ExportFormat.Full)
         {
-            return this.ToDelimitedString('\t',format);
+            return this.ToDelimitedString('\t', format);
+        }
+
+#if NET45_OR_GREATER
+        private void LogException(Exception ex, [CallerMemberName]string methodName = "")
+        {
+#else
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private void LogException(Exception ex)
+        {
+            string methodName = new System.Diagnostics.StackFrame(1, false).GetMethod().Name;
+#endif
+            log.Error(string.Format("{0}: {1} - {2}", methodName, ex.GetType().Name, ex.Message), ex);
         }
     }
 }

--- a/aaLogReader/aaLogReader.cs
+++ b/aaLogReader/aaLogReader.cs
@@ -1,13 +1,10 @@
-﻿using System;
+﻿using aaLogReader.Helpers;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using aaLogReader.Helpers;
-using Newtonsoft.Json;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Net;
-using System.Net.NetworkInformation;
 
 namespace aaLogReader
 {

--- a/aaLogReader/aaLogReader.csproj
+++ b/aaLogReader/aaLogReader.csproj
@@ -13,6 +13,19 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- http://stackoverflow.com/a/12737781/29762 -->
+    <!-- Adding a custom constant will auto-magically append a comma and space to the pre-built constants.    -->
+    <!-- Move the comma delimiter to the end of each constant and remove the trailing comma when we're done.  -->
+    <DefineConstants Condition=" !$(DefineConstants.Contains(', NET')) ">$(DefineConstants)$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", "")), </DefineConstants>
+    <DefineConstants Condition=" $(DefineConstants.Contains(', NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(", NET"))))$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", "")), </DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 2.0 ">$(DefineConstants)NET20_OR_GREATER, </DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 3.5 ">$(DefineConstants)NET35_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 4.0 ">$(DefineConstants)NET40_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 4.5 ">$(DefineConstants)NET45_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(TargetFrameworkVersion.Replace('v', '')) >= 4.6 ">$(DefineConstants)NET46_OR_GREATER</DefineConstants>
+    <DefineConstants Condition=" $(DefineConstants.EndsWith(', ')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(", "))))</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>


### PR DESCRIPTION
Unit tests compare properties in `actual` and `expected` instances instead of explicitly testing literal values. This makes maintenance a bit easier and more readable.