### PR TITLE
Changed file sort order in the GetLogFilePathsForMessageNumber() ...

### DIFF
--- a/aaLogReader/aaLogReader.cs
+++ b/aaLogReader/aaLogReader.cs
@@ -959,7 +959,7 @@ namespace aaLogReader
             List<string> returnValue = new List<string>();
 
             //Now try to find the specific file where the
-            List<LogHeader> foundLogHeaders = this.IndexLogHeaders().FindAll(x => x.StartMsgNumber <= MessageNumber && MessageNumber <= x.EndMsgNumber).OrderBy(x => x.StartFileTime).ToList<LogHeader>();
+            List<LogHeader> foundLogHeaders = this.IndexLogHeaders().FindAll(x => x.StartMsgNumber <= MessageNumber && MessageNumber <= x.EndMsgNumber).OrderByDescending(x => x.StartFileTime).ToList<LogHeader>();
 
             if (foundLogHeaders.Count > 0)
             {


### PR DESCRIPTION
…method so most recent file is first

There is a comment in the aaLogReader.GetRecordByMessageNumber() method at line 1040 saying that message numbers can be reused so it returns the first log record encountered with that message number. The GetLogFIlePathsForMessageNumber() method sorts the files by time in ascending order, so the oldest file will be used.

For my uses, anyway, that's backwards. The stuff I'm working on needs methods such as GetRecordByMessageNumber() and GetRecordsByStartMessageNumberAndCount() to return the most recent record.

The use case is processing new log records in batches where it needs to start each new batch at the next record after it left off on the previous batch. I cannot use GetUnreadRecords() for this due to other factors, but GetRecordsByStartMessageNumberAndCount() works if it always picks up at the most recent log file containing the given message number.

This PR changes one line in GetLogFilePathsForMessageNumber() to sort by time descending so the most recent file is used. GetLogFIlePathsForMessageNumber() is only called from GetRecordByMessageNumber(), so hopefully that change is OK.

Are there use cases where the oldest file containing that message number should be found instead? If so, I could add a parameter to specify the sort direction, but that would trickle out to other methods.